### PR TITLE
Cleanups and arrow function fixes

### DIFF
--- a/spec/abstract-operations.html
+++ b/spec/abstract-operations.html
@@ -2,7 +2,7 @@
   <h1>Abstract Operations</h1>
   <emu-clause id="abstract-ops-async-function-create" aoid="AsyncFunctionCreate">
     <h1>AsyncFunctionCreate(kind, ParameterList, Body, Scope, Strict)</h1>
-    <p>The abstract operation AsyncFunctionCreate requires the arguments: _kind_ which is one of (Normal, Method, Arrow), a parameter list production specified by |ParameterList|, a body production specified by |Body|, a Lexical Environment specified by _Scope_, and a Boolean flag _Strict_. AsyncFunctionCreate performs the following steps:</p>
+    <p>The abstract operation AsyncFunctionCreate requires the arguments: _kind_ which is one of (~Normal~, ~Method~, ~Arrow~), a parameter list production specified by |ParameterList|, a body production specified by |Body|, a Lexical Environment specified by _Scope_, and a Boolean flag _Strict_. AsyncFunctionCreate performs the following steps:</p>
     <emu-alg>
       1. Let _functionPrototype_ be the intrinsic object %AsyncFunctionPrototype%.
       2. Let _F_ be FunctionAllocate(_functionPrototype_, _Strict_, "non-constructor").
@@ -51,7 +51,7 @@
   </emu-clause>
 
   <emu-clause id="abstract-ops-awaited-fulfilled">
-    <h1>AsyncFunction Awaited fulfilled</h1>
+    <h1>AsyncFunction Awaited Fulfilled</h1>
     <p>Function _F_ is called with the parameter _value_.</p>
     <emu-alg>
       1. Let _asyncContext_ be the value of _F_'s [[AsyncContext]] internal slot.

--- a/spec/arrows.html
+++ b/spec/arrows.html
@@ -136,12 +136,8 @@
     <p><emu-prodref name="AsyncConciseBody" a="1" class="inline"></emu-prodref></p>
     <emu-alg>
       1. Let _promiseCapability_ be NewPromiseCapability(%Promise%).
-      2. ReturnIfAbrupt(_promiseCapability_).
-      3. Let _G_ be ObjectCreate(%GeneratorPrototype%, «[[GeneratorState]], [[GeneratorContext]]» ).
-      4. ReturnIfAbrupt(_G_).
-      5. Perform GeneratorStart(_G_, |AssignmentExpression|).
-      6. Perform AsyncFunctionStart(_G_, _promiseCapability_).
-      7. Return Completion{[[type]]: return, [[value]]: _promiseCapability_.[[Promise]], [[target]]: empty}.
+      1. Perform AsyncFunctionStart(_promiseCapability_, _FunctionBody_).
+      1. Return Completion{[[type]]: ~return~, [[value]]: _promiseCapability_.[[Promise]], [[target]]: ~empty~}.
     </emu-alg>
     <p><emu-prodref name="AsyncConciseBody" a="2" class="inline"></emu-prodref></p>
     <emu-alg>
@@ -156,7 +152,7 @@
       1. If the function code for this |AsyncArrowFunction| is strict mode code, let _strict_ be true. Otherwise, let _strict_ be false.
       2. Let _scope_ be the LexicalEnvironment of the running execution context.
       3. Let _parameters_ be |AsyncArrowBindingIdentifier|.
-      4. Let _closure_ be AsyncFunctionCreate("Arrow", _parameters_, |ConciseBody|, _scope_, _strict_).
+      4. Let _closure_ be AsyncFunctionCreate(~Arrow~, _parameters_, |ConciseBody|, _scope_, _strict_).
       5. Return _closure_.
     </emu-alg>
 
@@ -166,7 +162,7 @@
       2. Let _scope_ be the LexicalEnvironment of the running execution context.
       3. Let _head_ be CoveredAsyncArrowHead of |CoverCallExpressionAndAsyncArrowHead|.
       4. Let _parameters_ be the |ArrowFormalParameters| production matched by _head_.
-      5. Let _closure_ be AsyncFunctionCreate("Arrow", _parameters_, |ConciseBody|, _scope_, _strict_).
+      5. Let _closure_ be AsyncFunctionCreate(~Arrow~, _parameters_, |ConciseBody|, _scope_, _strict_).
       6. Return _closure_.
     </emu-alg>
   </emu-clause>

--- a/spec/async-function-objects.html
+++ b/spec/async-function-objects.html
@@ -8,11 +8,11 @@
     <p>The `AsyncFunction` constructor is designed to be subclassable. It may be used as the value of an extends clause of a class definition. Subclass constructors that intend to inherit the specified AsyncFunction behaviour must include a super call to the AsyncFunction constructor to create and initialize a subclass instances with the internal slots necessary for built-in async function behaviour.</p>
 
     <emu-clause id="async-function-constructor-arguments">
-      <h1>AsyncFunction(_p1_, _p2_, ..., _pn_, _body)</h1>
+      <h1>AsyncFunction(_p1_, _p2_, ..., _pn_, _body_)</h1>
 
       <p>The last argument specifies the body (executable code) of an async function. Any preceding arguments specify formal parameters.
 
-      <p>When the `AsyncFunction` function is called with some arguments _p1_, _p2_, ..., _pn_, _body_ (where _n_ migh tbe 0, that is, there are no _p_ arguments, and where _body) might also not be provided), the following steps are taken:</p>
+      <p>When the `AsyncFunction` function is called with some arguments _p1_, _p2_, ..., _pn_, _body_ (where _n_ might be 0, that is, there are no _p_ arguments, and where _body_ might also not be provided), the following steps are taken:</p>
 
       <emu-alg>
           1. Let _C_ be the active function object.
@@ -25,7 +25,7 @@
   </emu-clause>
   <emu-clause id="async-function-constructor-properties">
     <h1>Properties of the AsyncFunction constructor</h1>
-    
+
     <p>The AsyncFunction constructor is a standard built-in function object that inherits from the `Function` constructor. The value of the [[Prototype]] internal slot of the AsyncFunction constructor is the intrinsic object %Function%.
 
     <p>The value of the [[Extensible]] internal slot of the AsyncFunction constructor is *true*
@@ -51,7 +51,7 @@
     <p>The AsyncFunction prototype object is an ordinary object. In addition to being the value of the prototpe property of the %AsyncFunction% instrinsic, it is the %AsyncFunctionPrototype% intrinsic.</p>
 
     <p>The value of the [[Prototype]] internal slot of the AsyncFunction prototype object is the %FunctionPrototype% intrinsic object. The initial value of the [[Extensible]] internal slot of the AsyncFunction prototype object is *true*.</p>
-    
+
     <p>The AsyncFunction prototype object does not have a prototype property.</p>
     <emu-note>Presumably this could be Promise.prototype but I'm not sure this has any value?</emu-note>
 
@@ -76,7 +76,7 @@
   <emu-clause id="async-function-instances">
     <h1>AsyncFunction Instances</h1>
 
-    <p>Every AsyncFunction instance is an ECMAScript function object and has the internal slots listed in Table 27. The value of the [[FunctionKind]] internal slot for all such instances is "generator".</p>
+    <p>Every AsyncFunction instance is an ECMAScript function object and has the internal slots listed in Table 27. The value of the [[FunctionKind]] internal slot for all such instances is `"normal"`.</p>
 
     <p>Each AsyncFunction instance has the following own properties:</p>
 
@@ -91,7 +91,7 @@
     <emu-clause id="async-function-instances-name">
       <h1>name</h1>
 
-      <p>The specification for the `name` property of Function instances given in 19.2.4.2 also applies to Asyncfunction instances.</p>
+      <p>The specification for the `name` property of Function instances given in 19.2.4.2 also applies to AsyncFunction instances.</p>
     </emu-clause>
   </emu-clause>
 </emu-clause>

--- a/spec/declarations-and-expressions.html
+++ b/spec/declarations-and-expressions.html
@@ -101,12 +101,14 @@
       2. Let _name_ be StringValue of |BindingIdentifier|
       3. Let _F_ be AsyncFunctionCreate(~Normal~, |FormalParameters|, |AsyncFunctionBody|, _scope_, _strict_).
       4. Perform SetFunctionName(_F_, _name_).
+      5. Return _F_.
     </emu-alg>
     <p><emu-prodref name="AsyncFunctionDeclaration" a="2" class="inline"></emu-prodref></p>
     <emu-alg>
       1. If the function code for |AsyncFunctionDeclaration| is strict mode code, let _strict_ be *true*. Otherwise, let _strict_ be *false*.
       2. Let _F_ be AsyncFunctionCreate(~Normal~, |FormalParameters|, |AsyncFunctionBody|, _scope_, _strict_).
       3. Perform SetFunctionName(_F_, "default").
+      4. Return _F_.
     </emu-alg>
   </emu-clause>
 

--- a/spec/intro.html
+++ b/spec/intro.html
@@ -1,15 +1,15 @@
 <emu-intro id="intro">
   <h1>Introduction</h1>
-  <p>The introduction of Promises and Generators in ECMAScript presents an opportunity to dramatically improve the language-level model for writing asynchronous code in ECMAScript.</p>
+  <p>The introduction of promises and generators in ECMAScript presents an opportunity to dramatically improve the language-level model for writing asynchronous code in ECMAScript.</p>
 
-  <p>A similar proposal was made with <a href="http://wiki.ecmascript.org/doku.php?id=strawman:deferred_functions">Defered Functions</a> during ES6 discussions.  The proposal here supports the same use cases, using similar or the same syntax, but directly building upon generators and promises instead of defining custom mechanisms.</p>
+  <p>A similar proposal was made with <a href="http://wiki.ecmascript.org/doku.php?id=strawman:deferred_functions">Defered Functions</a> during ES6 discussions.  The proposal here supports the same use cases, using similar or the same syntax, but directly building upon control flow structures parallel to those of generators, and using promises for the return type, instead of defining custom mechanisms.</p>
 
   <p>Development of this proposal is happening at <a href="https://github.com/tc39/ecmascript-asyncawait">https://github.com/tc39/ecmascript-asyncawait</a>. Please file issues there. Non-trivial contributions are limited to TC39 members but pull requests for minor issues are welcome and encouraged!</p>
 
   <emu-intro id="status">
     <h1>Status of this proposal</h1>
 
-    <p>This proposal was accepted into stage 1 ("Proposal") of the ECMASCript 7 <a href="https://docs.google.com/document/d/1QbEE0BsO4lvl7NFTn5WXWeiEIBfaVUF7Dk0hpPpPDzU">spec  process</a> in January 2014 (<a href="http://esdiscuss.org/notes/2014-01-30#async-await">discussion</a>).</p>
+    <p>This proposal was accepted into stage 1 ("Proposal") of the ECMAScript <a href="https://docs.google.com/document/d/1QbEE0BsO4lvl7NFTn5WXWeiEIBfaVUF7Dk0hpPpPDzU">spec process</a> in January 2014 (<a href="https://esdiscuss.org/notes/2014-01-30#async-await">discussion</a>).</p>
   </emu-intro>
   <emu-intro id="examples">
     <h1>Examples</h1>
@@ -18,9 +18,9 @@
 
     <pre><code lang="javascript">
     function chainAnimationsPromise(elem, animations) {
-        var ret = null;
-        var p = currentPromise;
-        for(let anim of animations) {
+        let ret = null;
+        let p = currentPromise;
+        for(const anim of animations) {
             p = p.then(function(val) {
                 ret = val;
                 return anim(elem);
@@ -35,16 +35,16 @@
     </code></pre>
 
     <p>Already with promises, the code is much improved from a straight callback style, where this sort of looping and exception handling is challenging.</p>
-    
+
 
     <a href="http://taskjs.org">Task.js</a> and similar libraries offer a way to use generators to further simplify the code maintaining the same meaning:
 
     <pre><code class="javascript">
     function chainAnimationsGenerator(elem, animations) {
         return spawn(function*() {
-            var ret = null;
+            let ret = null;
             try {
-                for(let anim of animations) {
+                for(const anim of animations) {
                     ret = yield anim(elem);
                 }
             } catch(e) { /* ignore and keep going */ }
@@ -55,13 +55,13 @@
 
     <p>This is a marked improvement.  All of the promise boilerplate above and beyond the semantic content of the code is removed, and the body of the inner function represents user intent.  However, there is an outer layer of boilerplate to wrap the code in an additional generator function and pass it to a library to convert to a promise.  This layer needs to be repeated in every function that uses this mechanism to produce a promise.  This is so common in typical async Javascript code, that there is value in removing the need for the remaining boilerplate.</p>
 
-    <p>With async functions, all the remaining boiler plate is removed, leaving only the semantically meaningful code in the program text:</p>
+    <p>With async functions, all the remaining boilerplate is removed, leaving only the semantically meaningful code in the program text:</p>
 
     <pre><code class="javascript">
     async function chainAnimationsAsync(elem, animations) {
-        var ret = null;
+        let ret = null;
         try {
-            for(let anim of animations) {
+            for(const anim of animations) {
                 ret = await anim(elem);
             }
         } catch(e) { /* ignore and keep going */ }


### PR DESCRIPTION
- Fix async arrow functions to follow the new paradigm of #50 as well
- Typo and editorial fixes
- [[FunctionKind]] is "normal", whereas function kind for FunctionAllocate is "non-constructor"; this is consistent, whereas before there were non-constructor generators
